### PR TITLE
chore: Postgres가 없어 CI가 실패하는 문제 수정

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,8 +4,24 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_DB: flask-template-test
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     strategy:
       matrix:
         python-version: [3.8]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,9 @@ def fx_config_data() -> dict:
         'debug': False,
         'cross_origin': [],
         'database': {
-            'url': 'postgresql://localhost:5432/flask-template-test',
+            'url':
+                'postgresql://postgres:postgres@localhost:5432/'
+                'flask-template-test',
         }
     }
 


### PR DESCRIPTION
DB 접근이 필요한 테스트가 추가되며 CI가 깨지고 있습니다.
Postgresql를 설치한 후 CI를 돌릴 수 있도록 service를 설정합니다.
